### PR TITLE
Move SO_REUSEADDR helper to BFSocket module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,7 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
 # Librairie commune libBox
 add_library(BoxFoundation
         src/lib/BFCommon.c
+        src/lib/BFSocket.c
         src/lib/BFUdp.c
         src/lib/BFUdpServer.c
         src/lib/BFUdpClient.c

--- a/include/box/BFCommon.h
+++ b/include/box/BFCommon.h
@@ -40,9 +40,6 @@ enum {
 // Helper d'erreur fatale (arrête le programme avec perror)
 void BFFatal(const char *message);
 
-// Active l'option SO_REUSEADDR sur le socket
-int setReuseAddress(int fileDescriptor);
-
 #ifdef __cplusplus
 }
 #endif

--- a/include/box/BFSocket.h
+++ b/include/box/BFSocket.h
@@ -1,0 +1,14 @@
+#ifndef BF_SOCKET_H
+#define BF_SOCKET_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int BFSocketSetReuseAddress(int fileDescriptor);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // BF_SOCKET_H

--- a/src/lib/BFCommon.c
+++ b/src/lib/BFCommon.c
@@ -2,16 +2,8 @@
 
 #include <stdlib.h>
 #include <stdio.h>
-#include <errno.h>
-#include <sys/socket.h>
-#include <netinet/in.h>
 
 void BFFatal(const char *message) {
     perror(message);
     exit(EXIT_FAILURE);
-}
-
-int setReuseAddress(int fileDescriptor) {
-    int yes = 1;
-    return setsockopt(fileDescriptor, SOL_SOCKET, SO_REUSEADDR, &yes, sizeof(yes));
 }

--- a/src/lib/BFSocket.c
+++ b/src/lib/BFSocket.c
@@ -1,0 +1,9 @@
+#include "box/BFSocket.h"
+
+#include <sys/socket.h>
+#include <netinet/in.h>
+
+int BFSocketSetReuseAddress(int fileDescriptor) {
+    int yes = 1;
+    return setsockopt(fileDescriptor, SOL_SOCKET, SO_REUSEADDR, &yes, sizeof(yes));
+}

--- a/src/lib/BFUdpServer.c
+++ b/src/lib/BFUdpServer.c
@@ -1,5 +1,5 @@
 #include "box/BFUdpServer.h"
-#include "box/BFCommon.h"
+#include "box/BFSocket.h"
 
 #include <string.h>
 #include <errno.h>
@@ -12,7 +12,7 @@ int BFUdpServer(uint16_t port) {
     int fileDescriptor = socket(AF_INET, SOCK_DGRAM, 0);
     if (fileDescriptor < 0) return -1;
 
-    (void)setReuseAddress(fileDescriptor);
+    (void)BFSocketSetReuseAddress(fileDescriptor);
 
     struct sockaddr_in address;
     memset(&address, 0, sizeof(address));


### PR DESCRIPTION
## Summary
- introduce new `BFSocket` module for socket utilities
- migrate `setReuseAddress` to `BFSocketSetReuseAddress`
- update UDP server and build configuration to use the new helper

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_68c142f318dc832a8e340ff380ec210f