### PR TITLE
feat(shared): add BFSharedDictionary (thread-safe string map)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,7 @@ add_library(BoxFoundation
         src/lib/BFMemory.c
         src/lib/BFRunloop.c
         src/lib/BFSharedArray.c
+        src/lib/BFSharedDictionary.c
         src/lib/BFUdp.c
         src/lib/BFUdpServer.c
         src/lib/BFUdpClient.c
@@ -153,6 +154,12 @@ add_executable(test_BFSharedArray test/test_BFSharedArray.c)
 target_include_directories(test_BFSharedArray PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include)
 target_link_libraries(test_BFSharedArray PRIVATE BoxFoundation)
 add_test(NAME test_BFSharedArray COMMAND test_BFSharedArray)
+
+# BFSharedDictionary unit test
+add_executable(test_BFSharedDictionary test/test_BFSharedDictionary.c)
+target_include_directories(test_BFSharedDictionary PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include)
+target_link_libraries(test_BFSharedDictionary PRIVATE BoxFoundation)
+add_test(NAME test_BFSharedDictionary COMMAND test_BFSharedDictionary)
 
 # Cible utilitaire : génération de certificats autosignés (build dir)
 add_custom_target(certs

--- a/README.md
+++ b/README.md
@@ -198,6 +198,34 @@ Ce dépôt suit une convention de nommage pour la bibliothèque "BoxFoundation" 
 - Tests: utiliser le préfixe `test_` suivi du nom du composant.
   - Exemple: `test/test_BFBoxProtocol.c` avec la cible CMake `test_BFBoxProtocol`.
 
+## Conteneurs partagés (BoxFoundation)
+
+Deux conteneurs thread-safe simples sont fournis:
+
+- `BFSharedArray`: Tableau pseudo-indexé basé sur une liste doublement chaînée.
+  - Opérations: Push (fin), Unshift (début), Insert (à l'index), Get, Set, RemoveAt, Clear.
+  - Sécurité: Accès protégé par mutex; allocations via `BFMemory`.
+- `BFSharedDictionary`: Dictionnaire à clés chaîne de caractères.
+  - Implémentation: table de hachage avec chaînage séparé; clés dupliquées en interne.
+  - API: Create/Free/Count, Set/Get/Remove, Clear; callback optionnel pour détruire les valeurs restantes.
+
+Exemple rapide (BFSharedDictionary):
+
+```
+#include "box/BFSharedDictionary.h"
+#include "box/BFMemory.h"
+
+static void destroy_value(void *p) { BFMemoryRelease(p); }
+
+BFSharedDictionary *d = BFSharedDictionaryCreate(destroy_value);
+char *val = (char*)BFMemoryAllocate(6); // "hello\0"
+memcpy(val, "hello", 6);
+(void)BFSharedDictionarySet(d, "key", val);
+char *got = (char*)BFSharedDictionaryGet(d, "key");
+// ... utiliser got ...
+BFSharedDictionaryFree(d);
+```
+
 - Macros d’options CMake: préfixe `BOX_`.
   - Exemple: `BOX_USE_PRESHAREKEY` (alias rétrocompatible `BOX_USE_PSK`).
 

--- a/include/box/BFSharedDictionary.h
+++ b/include/box/BFSharedDictionary.h
@@ -1,0 +1,42 @@
+// BFSharedDictionary — thread-safe string-keyed dictionary (key: const char*, value: void*)
+// - Internally duplicates keys (BFMemory), and optionally destroys values via callback on Clear/Free.
+// - Single mutex guards the whole table for simplicity and correctness.
+
+#ifndef BF_SHARED_DICTIONARY_H
+#define BF_SHARED_DICTIONARY_H
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct BFSharedDictionary BFSharedDictionary;
+
+typedef void (*BFSharedDictionaryDestroyValue)(void *value);
+
+// Lifecycle
+BFSharedDictionary *BFSharedDictionaryCreate(BFSharedDictionaryDestroyValue destroy_cb);
+void                BFSharedDictionaryFree(BFSharedDictionary *dict);
+
+// Query
+size_t BFSharedDictionaryCount(BFSharedDictionary *dict);
+
+// Set/Insert: inserts or replaces value for key. Returns 0 on success, BF_ERR on failure.
+int    BFSharedDictionarySet(BFSharedDictionary *dict, const char *key, void *value);
+
+// Get: returns stored value pointer or NULL if not found.
+void  *BFSharedDictionaryGet(BFSharedDictionary *dict, const char *key);
+
+// Remove: removes entry and returns the stored value (caller owns it), or NULL if not found.
+void  *BFSharedDictionaryRemove(BFSharedDictionary *dict, const char *key);
+
+// Clear all entries; calls destroy_cb on each value if provided.
+int    BFSharedDictionaryClear(BFSharedDictionary *dict);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // BF_SHARED_DICTIONARY_H
+

--- a/src/lib/BFSharedDictionary.c
+++ b/src/lib/BFSharedDictionary.c
@@ -1,0 +1,189 @@
+#include "box/BFSharedDictionary.h"
+
+#include "box/BFCommon.h"
+#include "box/BFMemory.h"
+
+#include <pthread.h>
+#include <string.h>
+
+typedef struct BFDictNode {
+    char              *key;   // duplicated
+    void              *value; // stored pointer
+    struct BFDictNode *next;
+} BFDictNode;
+
+struct BFSharedDictionary {
+    pthread_mutex_t               mutex;
+    BFDictNode                  **buckets;
+    size_t                        bucketCount;
+    size_t                        count;
+    BFSharedDictionaryDestroyValue destroy_cb; // optional
+};
+
+static unsigned long djb2(const char *s) {
+    unsigned long h = 5381UL;
+    int           c = 0;
+    while (s && (c = *s++) != 0) {
+        h = ((h << 5) + h) + (unsigned long)c; // h*33 + c
+    }
+    return h;
+}
+
+static size_t pick_bucket(const char *key, size_t bucketCount) {
+    unsigned long h = djb2(key);
+    return (size_t)(h % (bucketCount ? bucketCount : 1U));
+}
+
+static char *dup_cstr(const char *s) {
+    if (!s)
+        return NULL;
+    size_t n  = strlen(s);
+    char  *cp = (char *)BFMemoryAllocate(n + 1U);
+    if (!cp)
+        return NULL;
+    memcpy(cp, s, n);
+    cp[n] = '\0';
+    return cp;
+}
+
+BFSharedDictionary *BFSharedDictionaryCreate(BFSharedDictionaryDestroyValue destroy_cb) {
+    const size_t buckets = 256U; // simple default
+    BFSharedDictionary *d = (BFSharedDictionary *)BFMemoryAllocate(sizeof(*d));
+    if (!d)
+        return NULL;
+    d->buckets = (BFDictNode **)BFMemoryAllocate(sizeof(BFDictNode *) * buckets);
+    if (!d->buckets) {
+        BFMemoryRelease(d);
+        return NULL;
+    }
+    memset(d->buckets, 0, sizeof(BFDictNode *) * buckets);
+    d->bucketCount = buckets;
+    d->count       = 0U;
+    d->destroy_cb  = destroy_cb;
+    (void)pthread_mutex_init(&d->mutex, NULL);
+    return d;
+}
+
+void BFSharedDictionaryFree(BFSharedDictionary *dict) {
+    if (!dict)
+        return;
+    (void)BFSharedDictionaryClear(dict);
+    BFMemoryRelease(dict->buckets);
+    pthread_mutex_destroy(&dict->mutex);
+    BFMemoryRelease(dict);
+}
+
+size_t BFSharedDictionaryCount(BFSharedDictionary *dict) {
+    if (!dict)
+        return 0U;
+    pthread_mutex_lock(&dict->mutex);
+    size_t n = dict->count;
+    pthread_mutex_unlock(&dict->mutex);
+    return n;
+}
+
+int BFSharedDictionarySet(BFSharedDictionary *dict, const char *key, void *value) {
+    if (!dict || !key)
+        return BF_ERR;
+    size_t b = pick_bucket(key, dict->bucketCount);
+
+    pthread_mutex_lock(&dict->mutex);
+    BFDictNode *p = dict->buckets[b];
+    while (p) {
+        if (strcmp(p->key, key) == 0) {
+            // replace
+            if (dict->destroy_cb && p->value && p->value != value) {
+                dict->destroy_cb(p->value);
+            }
+            p->value = value;
+            pthread_mutex_unlock(&dict->mutex);
+            return BF_OK;
+        }
+        p = p->next;
+    }
+    // insert new at head
+    BFDictNode *n = (BFDictNode *)BFMemoryAllocate(sizeof(*n));
+    if (!n) {
+        pthread_mutex_unlock(&dict->mutex);
+        return BF_ERR;
+    }
+    n->key   = dup_cstr(key);
+    n->value = value;
+    n->next  = dict->buckets[b];
+    dict->buckets[b] = n;
+    dict->count++;
+    pthread_mutex_unlock(&dict->mutex);
+    return BF_OK;
+}
+
+void *BFSharedDictionaryGet(BFSharedDictionary *dict, const char *key) {
+    if (!dict || !key)
+        return NULL;
+    size_t b = pick_bucket(key, dict->bucketCount);
+    pthread_mutex_lock(&dict->mutex);
+    BFDictNode *p = dict->buckets[b];
+    while (p) {
+        if (strcmp(p->key, key) == 0) {
+            void *v = p->value;
+            pthread_mutex_unlock(&dict->mutex);
+            return v;
+        }
+        p = p->next;
+    }
+    pthread_mutex_unlock(&dict->mutex);
+    return NULL;
+}
+
+void *BFSharedDictionaryRemove(BFSharedDictionary *dict, const char *key) {
+    if (!dict || !key)
+        return NULL;
+    size_t b = pick_bucket(key, dict->bucketCount);
+    pthread_mutex_lock(&dict->mutex);
+    BFDictNode *p = dict->buckets[b];
+    BFDictNode *q = NULL;
+    while (p) {
+        if (strcmp(p->key, key) == 0) {
+            if (q)
+                q->next = p->next;
+            else
+                dict->buckets[b] = p->next;
+            dict->count--;
+            void *val = p->value;
+            char *k    = p->key;
+            pthread_mutex_unlock(&dict->mutex);
+            BFMemoryRelease(k);
+            BFMemoryRelease(p);
+            return val;
+        }
+        q = p;
+        p = p->next;
+    }
+    pthread_mutex_unlock(&dict->mutex);
+    return NULL;
+}
+
+int BFSharedDictionaryClear(BFSharedDictionary *dict) {
+    if (!dict)
+        return BF_ERR;
+    pthread_mutex_lock(&dict->mutex);
+    BFDictNode **b = dict->buckets;
+    size_t       N = dict->bucketCount;
+    dict->count    = 0U;
+    dict->buckets  = b; // unchanged
+    pthread_mutex_unlock(&dict->mutex);
+
+    for (size_t i = 0; i < N; ++i) {
+        BFDictNode *p = b[i];
+        b[i]          = NULL;
+        while (p) {
+            BFDictNode *nxt = p->next;
+            if (dict->destroy_cb && p->value)
+                dict->destroy_cb(p->value);
+            BFMemoryRelease(p->key);
+            BFMemoryRelease(p);
+            p = nxt;
+        }
+    }
+    return BF_OK;
+}
+

--- a/test/test_BFSharedDictionary.c
+++ b/test/test_BFSharedDictionary.c
@@ -1,0 +1,94 @@
+#include "box/BFSharedDictionary.h"
+#include "box/BFMemory.h"
+
+#include <assert.h>
+#include <pthread.h>
+#include <stdio.h>
+#include <string.h>
+
+typedef struct StrBox {
+    char *s;
+} StrBox;
+
+static int g_destroyed = 0;
+
+static void destroy_value(void *ptr) {
+    if (ptr) {
+        StrBox *b = (StrBox *)ptr;
+        if (b->s)
+            BFMemoryRelease(b->s);
+        BFMemoryRelease(b);
+        g_destroyed++;
+    }
+}
+
+static StrBox *make_box(const char *txt) {
+    StrBox *b = (StrBox *)BFMemoryAllocate(sizeof(StrBox));
+    assert(b != NULL);
+    size_t n = strlen(txt);
+    b->s     = (char *)BFMemoryAllocate(n + 1U);
+    memcpy(b->s, txt, n);
+    b->s[n] = '\0';
+    return b;
+}
+
+static void *thread_insert(void *arg) {
+    BFSharedDictionary *d = (BFSharedDictionary *)arg;
+    // Insert 100 keys unique to this thread (prefix tX_)
+    char key[32];
+    for (int i = 0; i < 100; ++i) {
+        snprintf(key, sizeof(key), "t%p_%d", (void *)pthread_self(), i);
+        (void)BFSharedDictionarySet(d, key, make_box(key));
+    }
+    return NULL;
+}
+
+int main(void) {
+    g_destroyed = 0;
+    BFSharedDictionary *d = BFSharedDictionaryCreate(destroy_value);
+    assert(d != NULL);
+    assert(BFSharedDictionaryCount(d) == 0U);
+
+    // Basic set/get/replace/remove
+    assert(BFSharedDictionarySet(d, "a", make_box("va")) == 0);
+    assert(BFSharedDictionarySet(d, "b", make_box("vb")) == 0);
+    assert(BFSharedDictionaryCount(d) == 2U);
+    StrBox *ba = (StrBox *)BFSharedDictionaryGet(d, "a");
+    assert(ba && strcmp(ba->s, "va") == 0);
+
+    // Replace should destroy old value via destroy_cb
+    int before_destroy = g_destroyed;
+    assert(BFSharedDictionarySet(d, "a", make_box("va2")) == 0);
+    assert(g_destroyed == before_destroy + 1);
+    ba = (StrBox *)BFSharedDictionaryGet(d, "a");
+    assert(ba && strcmp(ba->s, "va2") == 0);
+
+    // Remove returns value and does not call destroy_cb for it (caller must free)
+    StrBox *removed = (StrBox *)BFSharedDictionaryRemove(d, "b");
+    assert(removed && strcmp(removed->s, "vb") == 0);
+    BFMemoryRelease(removed->s);
+    BFMemoryRelease(removed);
+    assert(BFSharedDictionaryGet(d, "b") == NULL);
+
+    // Concurrency smoke test: 4 threads insert 100 items each
+    pthread_t th[4];
+    for (int i = 0; i < 4; ++i) {
+        assert(pthread_create(&th[i], NULL, thread_insert, d) == 0);
+    }
+    for (int i = 0; i < 4; ++i) {
+        (void)pthread_join(th[i], NULL);
+    }
+    // Count should be at least 401 (previous key "a" plus ~400 inserts). Collisions may replace, but keys include thread id so unique.
+    assert(BFSharedDictionaryCount(d) >= 401U);
+
+    // Clear destroys all remaining values
+    size_t before_clear = BFSharedDictionaryCount(d);
+    assert(BFSharedDictionaryClear(d) == 0);
+    assert(BFSharedDictionaryCount(d) == 0U);
+    assert(g_destroyed >= (int)before_clear);
+
+    BFSharedDictionaryFree(d);
+    printf("test_BFSharedDictionary: OK\n");
+    return 0;
+}
+


### PR DESCRIPTION
Add BFSharedDictionary to BoxFoundation:
- String-keyed, thread-safe dictionary with hash-table + chaining
- Keys duplicated internally; optional destroy callback for values
- API: Create/Free/Count, Set/Get/Remove, Clear

Also adds unit tests (test_BFSharedDictionary) and README docs.